### PR TITLE
Use simpler cheat signature and deduplicate tests

### DIFF
--- a/exercises/chapter11/test/Main.purs
+++ b/exercises/chapter11/test/Main.purs
@@ -86,10 +86,10 @@ This line should have been automatically deleted by resetSolutions.sh. See Chapt
     suite "Exercises Group - Monad Transformers" do
       suite "safeDivide" do
         test "should fail when dividing by zero" do
-          Assert.equal (Left "Divide by zero!") 
-            $ unwrap $ runExceptT $ safeDivide 5 0 
-        test "should successfully divide for any other input" do 
-          Assert.equal (Right 2) $ unwrap $ runExceptT $ safeDivide 6 3 
+          Assert.equal (Left "Divide by zero!")
+            $ unwrap $ runExceptT $ safeDivide 5 0
+        test "should successfully divide for any other input" do
+          Assert.equal (Right 2) $ unwrap $ runExceptT $ safeDivide 6 3
       suite "parser" do
         let
           runParser p s = unwrap $ runExceptT $ runWriterT $ runStateT p s
@@ -145,35 +145,28 @@ This line should have been automatically deleted by resetSolutions.sh. See Chapt
             $ runParser asOrBs "foobar"
 
     suite "Exercises Group - The RWS Monad" do
-      let 
+      let
         runGame :: Game Unit -> RWSResult GameState Unit (List String)
         runGame testGame = runRWS testGame env initialGameState
         env = GameEnvironment { debugMode: false, playerName: "Phil" }
 
-        playerHasAllItems (GameState {inventory}) = inventory == S.fromFoldable [Candle, Matches]  
+        playerHasAllItems (GameState {inventory}) = inventory == S.fromFoldable [Candle, Matches]
         mapIsEmpty (GameState {items}) = M.isEmpty items
         expectedLogs = ("You now have the Candle" : "You now have the Matches" : L.Nil)
 
-      test "adds all items to your inventory when cheating" do 
-        let (RWSResult actualState _ log) = runGame cheat 
-        Assert.assert "Expected player to have both Candle and Matches" $ playerHasAllItems actualState
-        Assert.assert "Expected map to no longer have any items" $ mapIsEmpty actualState
-        Assert.equal expectedLogs $ L.sort log
+      suite "adds all items to your inventory when cheating" do
+        let
+          runCheatTest label testGame =
+            test label do
+              let (RWSResult actualState _ log) = runGame testGame
+              Assert.assert "Expected player to have both Candle and Matches" $ playerHasAllItems actualState
+              Assert.assert "Expected map to no longer have any items" $ mapIsEmpty actualState
+              Assert.equal expectedLogs $ L.sort log
 
-        let (RWSResult actualState _ log) = runGame (move 0 (-1) *> move 0 1 *> cheat)
-        Assert.assert "Expected player to have both Candle and Matches" $ playerHasAllItems actualState
-        Assert.assert "Expected map to no longer have any items" $ mapIsEmpty actualState
-        Assert.equal expectedLogs $ L.sort log
-
-        let (RWSResult actualState _ log) = runGame (pickUp Matches *> cheat)
-        Assert.assert "Expected player to have both Candle and Matches" $ playerHasAllItems actualState
-        Assert.assert "Expected map to no longer have any items" $ mapIsEmpty actualState
-        Assert.equal expectedLogs $ L.sort log
-
-        let (RWSResult actualState _ log) = runGame (pickUp Matches *> move 0 1 *> pickUp Candle *> cheat)
-        Assert.assert "Expected player to have both Candle and Matches" $ playerHasAllItems actualState
-        Assert.assert "Expected map to no longer have any items" $ mapIsEmpty actualState
-        Assert.equal expectedLogs $ L.sort log
+        runCheatTest "only cheat" cheat
+        runCheatTest "move and cheat" $ move 0 (-1) *> move 0 1 *> cheat
+        runCheatTest "pickup matches and cheat" $ pickUp Matches *> cheat
+        runCheatTest "pickup all, move, and cheat" $ pickUp Matches *> move 0 1 *> pickUp Candle *> cheat
 
 {- This line should have been automatically deleted by resetSolutions.sh. See Chapter 2 for instructions.
 -}

--- a/exercises/chapter11/test/no-peeking/Solutions.purs
+++ b/exercises/chapter11/test/no-peeking/Solutions.purs
@@ -4,13 +4,11 @@ import Prelude
 
 import Control.Alt ((<|>))
 import Control.Monad.Except (ExceptT, throwError)
-import Control.Monad.RWS (RWS)
 import Control.Monad.Reader (Reader, ReaderT, ask, lift, local, runReader, runReaderT)
 import Control.Monad.State (State, StateT, get, put, execState, modify_)
 import Control.Monad.Writer (Writer, WriterT, tell, runWriter, execWriterT)
 import Data.Array (some)
 import Data.Foldable (fold, foldl)
-import Data.GameEnvironment (GameEnvironment)
 import Data.GameState (GameState(..))
 import Data.Identity (Identity)
 import Data.List ((:))
@@ -26,6 +24,7 @@ import Data.String.CodeUnits (stripPrefix, toCharArray)
 import Data.String.Pattern (Pattern(..))
 import Data.Traversable (sequence, traverse_)
 import Data.Tuple (Tuple)
+import Game (Game)
 
 --
 
@@ -138,9 +137,10 @@ asFollowedByBs = do
 asOrBs :: Parser String
 asOrBs = fold <$> some (string "a" <|> string "b")
 
-cheat :: RWS GameEnvironment (L.List String) GameState Unit 
-cheat = do 
-  GameState state <- get 
+-- Note, that this function should be defined in Game.purs to avoid creating a circular dependency.
+cheat :: Game Unit
+cheat = do
+  GameState state <- get
   let newInventory = foldl S.union state.inventory state.items
   tell $ foldl (\acc x -> ("You now have the " <> show x) : acc) L.Nil $ S.unions state.items
   put $ GameState state { items = M.empty, inventory = newInventory }


### PR DESCRIPTION
Follow-up to https://github.com/purescript-contrib/purescript-book/pull/386

If users follow the [`scripts/resetSolutions.sh` workflow described in Ch2](https://book.purescript.org/chapter2.html#solving-exercises), then I don't think there's any circular dependency issues to reference `Game` in the testable version of `cheat` in `no-peeking/Solutions.purs`. See [this branch](https://github.com/milesfrain/purescript-book/commits/ch11-cheat-solved) for an example of how I'm assuming folks will solve the exercises in this chapter.

This PR simplifies that signature and also deduplicates some of the testing code.